### PR TITLE
Add OG meta tags and Profile nav link

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>corvid-agent | Status Dashboard</title>
-  <meta name="description" content="Live status dashboard for corvid-agent - monitoring packages, GitHub activity, Algorand wallet, and network stats.">
+  <meta name="description" content="Live operational dashboard for corvid-agent — monitoring packages, CI status, GitHub activity, Algorand wallet, and network health in real time.">
+  <meta property="og:title" content="corvid-agent | Status Dashboard">
+  <meta property="og:description" content="Live operational dashboard monitoring packages, CI, GitHub activity, and Algorand wallet.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://corvid-agent.github.io/agent-dashboard/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#x1F4CA;</text></svg>">
   <style>
     @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Inter:wght@300;400;500;600;700&display=swap');
@@ -793,9 +797,13 @@
           <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
           GitHub
         </a>
-        <a href="https://allo.info/account/YZAKVEGAKEGEBRATG6JU75BOMQDQXLNAJLCBHHMBYHUGEQJG5VXVBYC4OM" title="Algorand Explorer" target="_blank" rel="noopener">
+        <a href="https://corvid-agent.github.io/algo-explorer/" title="Algo Explorer">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="6.5"/><path d="M8 1.5v13M1.5 8h13"/><path d="M2.5 4.5h11M2.5 11.5h11"/></svg>
           Explorer
+        </a>
+        <a href="https://corvid-agent.github.io/agent-profile/" title="Agent Profile">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="5" r="3"/><path d="M2 14c0-3 2.7-5.5 6-5.5s6 2.5 6 5.5"/></svg>
+          Profile
         </a>
         <a href="#" class="active" title="Dashboard">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="1.5" y="1.5" width="5" height="5" rx="1"/><rect x="9.5" y="1.5" width="5" height="5" rx="1"/><rect x="1.5" y="9.5" width="5" height="5" rx="1"/><rect x="9.5" y="9.5" width="5" height="5" rx="1"/></svg>


### PR DESCRIPTION
## Summary
- Add Open Graph meta tags for better social sharing previews
- Add **Profile** nav link in header navigation for ecosystem cross-linking
- Update Explorer link to point to the algo-explorer app instead of allo.info
- Improve meta description with more operational detail

## Changes
- `index.html`: Added `og:title`, `og:description`, `og:type`, `og:url` meta tags
- `index.html`: Added Profile nav link with user icon SVG
- `index.html`: Updated Explorer nav link to point to ecosystem app

## Test plan
- [ ] Verify OG tags render correctly with a link preview tool
- [ ] Confirm Profile nav link navigates to agent-profile page
- [ ] Check all nav links work across ecosystem pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)