### PR TITLE
feat: ecosystem nav footer & harmonized tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       --bg-panel-hover: #1a1a25;
       --border: #1e1e2e;
       --text: #c8ccd8;
-      --text-dim: #6b7280;
+      --text-dim: #5a5f72;
       --text-bright: #f0f2f8;
       --accent: #6c5ce7;
       --accent-2: #00d2ff;
@@ -1107,6 +1107,23 @@
     </div>
 
   </div>
+
+  <footer style="text-align:center; padding:3rem 2rem; border-top:1px solid var(--border); max-width:1400px; margin:0 auto;">
+    <div style="display:flex; justify-content:center; gap:1.5rem; margin-bottom:1.2rem; flex-wrap:wrap;">
+      <a href="https://corvid-agent.github.io/" style="color:var(--text-dim); text-decoration:none; font-size:0.82rem;">Home</a>
+      <a href="https://corvid-agent.github.io/agent-profile/" style="color:var(--text-dim); text-decoration:none; font-size:0.82rem;">Profile</a>
+      <a href="https://corvid-agent.github.io/agent-dashboard/" style="color:var(--text-dim); text-decoration:none; font-size:0.82rem;">Dashboard</a>
+      <a href="https://corvid-agent.github.io/algo-explorer/" style="color:var(--text-dim); text-decoration:none; font-size:0.82rem;">Explorer</a>
+      <a href="https://corvid-agent.github.io/corvid-agent-chat/" style="color:var(--text-dim); text-decoration:none; font-size:0.82rem;">Chat</a>
+      <a href="https://corvid-agent.github.io/bw-cinema/" style="color:var(--text-dim); text-decoration:none; font-size:0.82rem;">Cinema</a>
+      <a href="https://github.com/corvid-agent" target="_blank" rel="noopener" style="color:var(--text-dim); text-decoration:none; font-size:0.82rem;">GitHub</a>
+    </div>
+    <p style="font-size:0.82rem; color:var(--text-dim);">
+      Built autonomously by <a href="https://github.com/corvid-agent" style="color:var(--accent); text-decoration:none;">corvid-agent</a> &middot;
+      On-chain identity on <a href="https://corvid-agent.github.io/algo-explorer/" style="color:var(--accent); text-decoration:none;">Algorand</a> &middot;
+      Powered by <a href="https://github.com/CorvidLabs" style="color:var(--accent); text-decoration:none;">CorvidLabs</a>
+    </p>
+  </footer>
 
   <script>
     // ── Constants ──


### PR DESCRIPTION
## Summary
- Add full ecosystem navigation footer with links to all corvid-agent sites (Home, Profile, Dashboard, Explorer, Chat, Cinema, GitHub)
- Fix `--text-dim` color to match the standardized palette (`#5a5f72`)

## Consistency
Matches the nav/footer pattern established in agent-profile and corvid-agent.github.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)